### PR TITLE
delete p_fuel in the gen dict when bidding

### DIFF
--- a/idaes/apps/grid_integration/coordinator.py
+++ b/idaes/apps/grid_integration/coordinator.py
@@ -285,6 +285,11 @@ class DoubleLoopCoordinator:
                 for t in range(options.ruc_horizon)
             ],
         }
+
+        # updated p_cost, so delete p_fuel
+        if "p_fuel" in gen_dict:
+            gen_dict.pop("p_fuel")
+
         return
 
     def _pass_DA_schedule_to_prescient(self, options, ruc_instance, schedule):
@@ -499,6 +504,11 @@ class DoubleLoopCoordinator:
             "cost_curve_type": "piecewise",
             "values": p_cost,
         }
+
+        # updated p_cost, so delete p_fuel
+        if "p_fuel" in gen_dict:
+            gen_dict.pop("p_fuel")
+            
         return
 
     def _pass_RT_schedule_to_prescient(


### PR DESCRIPTION
## Fixes
This PR fixes the warning that pops up when we provide both p_cost (from bidding) and p_fuel (from the data) for a generator after bidding.

## Summary/Motivation:


## Changes proposed in this PR:
- In the Coordinator, once we updated the p_cost for a generator by bidding, delete the p_fuel key in the generator dictionary if it exists.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
