### PR TITLE
Handle unavail dispatch

### DIFF
--- a/idaes/apps/grid_integration/forecaster.py
+++ b/idaes/apps/grid_integration/forecaster.py
@@ -25,6 +25,10 @@ class AbstractPriceForecaster(ABC):
     def forecast_real_time_prices(self, date, hour, bus, horizon, n_samples):
         pass
 
+    @abstractmethod
+    def forecast_day_ahead_prices(self, date, hour, bus, horizon, n_samples):
+        pass
+
 
 class PlaceHolderForecaster(AbstractPriceForecaster):
 
@@ -53,15 +57,20 @@ class PlaceHolderForecaster(AbstractPriceForecaster):
         rt_forecast = self.forecast_real_time_prices(
             date, hour, bus, horizon, n_samples
         )
-        da_forecast = self._forecast(
+        da_forecast = self.forecast_day_ahead_prices(
+            date, hour, bus, horizon, n_samples
+        )
+
+        return da_forecast, rt_forecast
+
+    def forecast_day_ahead_prices(self, date, hour, bus, horizon, n_samples):
+        return self._forecast(
             means=self.daily_da_price_means,
             stds=self.daily_da_price_stds,
             hour=hour,
             horizon=horizon,
             n_samples=n_samples,
         )
-
-        return da_forecast, rt_forecast
 
     def forecast_real_time_prices(self, date, hour, bus, horizon, n_samples):
         return self._forecast(

--- a/idaes/apps/grid_integration/tracker.py
+++ b/idaes/apps/grid_integration/tracker.py
@@ -14,6 +14,7 @@ import pandas as pd
 import pyomo.environ as pyo
 from pyomo.opt.base.solvers import OptSolver
 import os
+from itertools import zip_longest
 
 
 class Tracker:
@@ -23,7 +24,9 @@ class Tracker:
     with the DoubleLoopCoordinator.
     """
 
-    def __init__(self, tracking_model_object, tracking_horizon, n_tracking_hour, solver):
+    def __init__(
+        self, tracking_model_object, tracking_horizon, n_tracking_hour, solver
+    ):
 
         """
         Initializes the tracker object.
@@ -220,29 +223,16 @@ class Tracker:
             None
         """
 
-        self._add_tracking_dispatch_constraints()
-        return
-
-    def _add_tracking_dispatch_constraints(self):
-
-        """
-        Add tracking constraints to the model, i.e., power output needs
-        to follow market dispatch signals.
-
-        Arguments:
-            None
-
-        Returns:
-            None
-        """
-
         # declare a constraint list
-        self.model.tracking_dispatch_constraints = pyo.ConstraintList()
-        for t in self.time_set:
-            self.model.tracking_dispatch_constraints.add(
+        def tracking_dispatch_constraint_rule(m, t):
+            return (
                 self.power_output[t] + self.model.power_underdelivered[t]
                 == self.model.power_dispatch[t] + self.model.power_overdelivered[t]
             )
+
+        self.model.tracking_dispatch_constraints = pyo.Constraint(
+            self.time_set, rule=tracking_dispatch_constraint_rule
+        )
 
         return
 
@@ -346,8 +336,12 @@ class Tracker:
             None
         """
 
-        for t, dipsatch in zip(self.time_set, market_dispatch):
-            self.model.power_dispatch[t] = dipsatch
+        for t, dispatch in zip_longest(self.time_set, market_dispatch):
+            if dispatch is None:
+                self.model.tracking_dispatch_constraints[t].deactivate()
+            else:
+                self.model.power_dispatch[t] = dispatch
+                self.model.tracking_dispatch_constraints[t].activate()
 
         return
 


### PR DESCRIPTION
## Fixes
Handle the situation when no day-ahead dispatches and prices signals are available for tracker and bidder. 


## Summary/Motivation:
Handle the situation when no day-ahead dispatches and prices signals are available for tracker and bidder. Instead of assigning make-up signals for those time periods, we can simply deactivate the tracking signal constraint (power output[t] == market_dispatch[t]) in the tracker and unfix the day-ahead power in the bidder for those time periods. In this way, I anticipate the tracking problem will always be feasible while minimizing the objective function.


## Changes proposed in this PR:
- Deactivate tracking constraint when there is not enough dispatch signal.
- Unfix day_ahead_power when no realized DA signal.
- Add forecast_day_ahead_prices() method to the forecaster.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
